### PR TITLE
Added a custom logger to easily pass msgid and structured_data as parameters

### DIFF
--- a/rfc5424logging/__init__.py
+++ b/rfc5424logging/__init__.py
@@ -1,3 +1,4 @@
 from .handler import Rfc5424SysLogHandler
+from .logger import Rfc5424SysLogLogger
 
-__all__ = ['Rfc5424SysLogHandler', ]
+__all__ = ['Rfc5424SysLogHandler', 'Rfc5424SysLogLogger', ]

--- a/rfc5424logging/logger.py
+++ b/rfc5424logging/logger.py
@@ -1,0 +1,133 @@
+import logging
+
+from handler import NILVALUE
+
+
+class Rfc5424SysLogLogger(logging.Logger):
+    """
+    A Logger class which takes in additional information related to the RFC 5424 Syslog Protocol
+    (ie. msgid and structured_data), and passes it into the standard logging.Logger class as part of the extras
+    argument in the _log method.
+
+    This class overrides the following methods from logging.logger, which call the _log method:
+        - debug
+        - info
+        - warning
+        - error
+        - critical
+        - log
+    """
+
+    def __init__(self, name, level=logging.NOTSET):
+        super(Rfc5424SysLogLogger, self).__init__(name, level)
+
+    def debug(self, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'DEBUG'.
+
+        Args:
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).debug(msg, *args, **kwargs)
+
+    def info(self, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'INFO'.
+
+        Args:
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).info(msg, *args, **kwargs)
+
+    def warning(self, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'WARNING'.
+
+        Args:
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).warning(msg, *args, **kwargs)
+
+    def error(self, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'ERROR'.
+
+        Args:
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).error(msg, *args, **kwargs)
+
+    def critical(self, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'CRITICAL'.
+
+        Args:
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).critical(msg, *args, **kwargs)
+
+    def log(self, level, msg, msgid=NILVALUE, structured_data=None, *args, **kwargs):
+        """
+        Log 'msg % args' with the integer severity 'level'.
+
+        Args:
+            level:
+                Severity level as an integer
+            msg:
+                Message to log
+            msgid:
+                RFC 5424 MSGID
+            structured_data:
+                RFC 5424 STRUCTURED-DATA
+        """
+        if structured_data is None:
+            structured_data = {}
+        self._update(msgid, structured_data, kwargs)
+        super(Rfc5424SysLogLogger, self).log(level, msg, *args, **kwargs)
+
+    @staticmethod
+    def _update(msgid, structured_data, kwargs):
+        extra = dict(msgid=msgid, structured_data=structured_data)
+        if 'extra' not in kwargs or not isinstance(kwargs['extra'], dict):
+            kwargs['extra'] = dict()
+        kwargs['extra'].update(extra)

--- a/rfc5424logging/tests/test_basic.py
+++ b/rfc5424logging/tests/test_basic.py
@@ -1,15 +1,41 @@
-from unittest import TestCase
 import logging
-from rfc5424logging import Rfc5424SysLogHandler
+from sys import platform
+from unittest import TestCase
+
+from rfc5424logging import Rfc5424SysLogHandler, Rfc5424SysLogLogger
+
+ADDRESS = '/var/run/syslog' if platform == 'darwin' else ('127.0.0.1', 514)
 
 
 class TestRfc5424(TestCase):
     def test_basic(self):
-
-        logger = logging.getLogger('syslogtest')
+        logger = Rfc5424SysLogLogger('syslogtest')
         logger.setLevel(logging.INFO)
 
-        sh = Rfc5424SysLogHandler(address=('127.0.0.1', 514))
+        sh = Rfc5424SysLogHandler(ADDRESS)
         logger.addHandler(sh)
         msg_type = 'interesting'
-        logger.info('This is an %s message', msg_type)
+        logger.info('This is an {} message'.format(msg_type))
+
+    def test_basic_msgid(self):
+        logger = Rfc5424SysLogLogger('syslogtest')
+        logger.setLevel(logging.INFO)
+
+        sh = Rfc5424SysLogHandler(ADDRESS)
+        logger.addHandler(sh)
+        msg_type = 'interesting'
+        logger.info('This is an {} message with a msgid'.format(msg_type), msgid='TCPIN')
+
+    def test_basic_structured_data(self):
+        logger = Rfc5424SysLogLogger('syslogtest')
+        logger.setLevel(logging.INFO)
+
+        sh = Rfc5424SysLogHandler(ADDRESS)
+        logger.addHandler(sh)
+        msg_type = 'interesting'
+        structured_data = {
+            "exampleSDID@32473 iut": "3",
+            "eventSource": "Application",
+            "eventID": "1011"
+        }
+        logger.info('This is an {} message with structured_data'.format(msg_type), structured_data=structured_data)

--- a/rfc5424logging/tests/test_basic.py
+++ b/rfc5424logging/tests/test_basic.py
@@ -24,7 +24,7 @@ class TestRfc5424(TestCase):
         sh = Rfc5424SysLogHandler(ADDRESS)
         logger.addHandler(sh)
         msg_type = 'interesting'
-        logger.info('This is an {} message with a msgid'.format(msg_type), msgid='TCPIN')
+        logger.debug('This is an {} message with a msgid'.format(msg_type), msgid='TCPIN')
 
     def test_basic_structured_data(self):
         logger = Rfc5424SysLogLogger('syslogtest')
@@ -38,4 +38,4 @@ class TestRfc5424(TestCase):
             "eventSource": "Application",
             "eventID": "1011"
         }
-        logger.info('This is an {} message with structured_data'.format(msg_type), structured_data=structured_data)
+        logger.warning('This is an {} message with structured_data'.format(msg_type), structured_data=structured_data)

--- a/rfc5424logging/tests/test_basic.py
+++ b/rfc5424logging/tests/test_basic.py
@@ -4,13 +4,15 @@ from unittest import TestCase
 
 from rfc5424logging import Rfc5424SysLogHandler, Rfc5424SysLogLogger
 
+logging.setLoggerClass(Rfc5424SysLogLogger)
+
 ADDRESS = '/var/run/syslog' if platform == 'darwin' else ('127.0.0.1', 514)
 
 
 class TestRfc5424(TestCase):
     def test_basic(self):
-        logger = Rfc5424SysLogLogger('syslogtest')
-        logger.setLevel(logging.INFO)
+        logger = logging.getLogger('syslogtest')
+        logger.setLevel(logging.DEBUG)
 
         sh = Rfc5424SysLogHandler(ADDRESS)
         logger.addHandler(sh)
@@ -18,8 +20,8 @@ class TestRfc5424(TestCase):
         logger.info('This is an {} message'.format(msg_type))
 
     def test_basic_msgid(self):
-        logger = Rfc5424SysLogLogger('syslogtest')
-        logger.setLevel(logging.INFO)
+        logger = logging.getLogger('syslogtest')
+        logger.setLevel(logging.DEBUG)
 
         sh = Rfc5424SysLogHandler(ADDRESS)
         logger.addHandler(sh)
@@ -27,8 +29,8 @@ class TestRfc5424(TestCase):
         logger.debug('This is an {} message with a msgid'.format(msg_type), msgid='TCPIN')
 
     def test_basic_structured_data(self):
-        logger = Rfc5424SysLogLogger('syslogtest')
-        logger.setLevel(logging.INFO)
+        logger = logging.getLogger('syslogtest')
+        logger.setLevel(logging.DEBUG)
 
         sh = Rfc5424SysLogHandler(ADDRESS)
         logger.addHandler(sh)


### PR DESCRIPTION
Added a custom logger to easily pass `msgid` and `structured_data` as parameters

@jobec FYI I sent you an email asking about the ideal way to pass in `msgid` and `structured_data`. I added the custom logger here since @TheMikeGood and I would likely have to do it anyways, and I thought it can probably be reused by you or others. Please feel free to approve/reject.