### PR TITLE
Added BOM as an optional parameter to message.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Python package::
 Usage
 -----
 
-Basic
-~~~~~
+Basics
+~~~~~~
 
 After installing you can use this package like this:
 
@@ -53,8 +53,16 @@ After installing you can use this package like this:
 
 This will send the following message to the syslog server::
 
-    <14>1 2020-01-01T05:10:20.841485+01:00 myserver syslogtest 5252 - - This is an interesting message
+    <14>1 2020-01-01T05:10:20.841485+01:00 myserver syslogtest 5252 - - \xef\xbb\xbfThis is an interesting message
 
+Note the UTF8 Byte order mark (BOM) preceding the message. While required by
+`RFC 5424 section 6.4 <https://tools.ietf.org/html/rfc5424#section-6.4>`_ if the message is known to be UTF-8 encoded,
+there are still syslog receivers that cannot handle it. To bypass this limitation, set the ``msg_as_utf8`` parameter
+to ``False`` like this:
+
+.. code-block:: python
+
+    sh = Rfc5424SysLogHandler(address=('10.0.0.1', 514), msg_as_utf8=False)
 
 Extended
 ~~~~~~~~
@@ -90,7 +98,7 @@ Full blown example:
 
 That will send the following message to the syslog server::
 
-    <14>1 2020-01-01T05:10:20.841485+01:00 overridden_server_name my_wonderfull_app 555 some_unique_msgid [sd_id_1@32473 key1="value1"][sd_id2@32473 key3="value3" key2="value2"] This is an interesting message
+    <14>1 2020-01-01T05:10:20.841485+01:00 overridden_server_name my_wonderfull_app 555 some_unique_msgid [sd_id_1@32473 key1="value1"][sd_id2@32473 key3="value3" key2="value2"] \xef\xbb\xbfThis is an interesting message
 
 With logger adapter
 ~~~~~~~~~~~~~~~~~~~

--- a/rfc5424logging/handler.py
+++ b/rfc5424logging/handler.py
@@ -48,7 +48,9 @@ class Rfc5424SysLogHandler(SysLogHandler):
                  facility=SysLogHandler.LOG_USER,
                  socktype=socket.SOCK_DGRAM,
                  framing=FRAMING_NON_TRANSPARENT,
-                 hostname=None, appname=None, procid=None, structured_data=None, enterprise_id=None):
+                 hostname=None, appname=None, procid=None,
+                 structured_data=None, enterprise_id=None,
+                 bom=True):
         """
         Returns a new instance of the Rfc5424SysLogHandler class intended to communicate with
         a remote machine whose address is given by address in the form of a (host, port) tuple.
@@ -97,6 +99,9 @@ class Rfc5424SysLogHandler(SysLogHandler):
             enterprise_id (int):
                 Then Private Enterprise Number. This is used to compose the structured data IDs when
                 they do not include an Enterprise ID and are not one of the reserved structured data IDs
+            bom (bool):
+                If the syslog application has a good indication that the content of the message
+                is encoded in UTF-8, then it should include the BOM.
         """
         self.hostname = hostname
         self.appname = appname
@@ -104,6 +109,7 @@ class Rfc5424SysLogHandler(SysLogHandler):
         self.structured_data = structured_data
         self.enterprise_id = enterprise_id
         self.framing = framing
+        self.bom = bom
 
         if self.hostname is None or self.hostname == '':
             self.hostname = socket.gethostname()
@@ -308,7 +314,10 @@ class Rfc5424SysLogHandler(SysLogHandler):
 
             # MSG
             msg = self.format(record)
-            msg = b''.join((BOM_UTF8, msg.encode('utf-8')))
+            if self.bom:
+                msg = b''.join((BOM_UTF8, msg.encode('utf-8')))
+            else:
+                msg = msg.encode('utf-8')
 
             # SYSLOG-MSG
             # with RFC6587 framing


### PR DESCRIPTION
The BOM part of RFC5424 (A.8) is described with SHOULD rather than MUST, which means it would be OK to leave out the BOM part. The default option includes BOM in front of the message, but leaves user the option to opt-out.

In my case, I wish to log pure JSON, but also have the benefits of Syslog structure and protocol in my log mesaages. This logger, in accordance with RFC5424, modifies my message - making it a non valid JSON. 