### PR TITLE
Local extras should override extras given in init

### DIFF
--- a/rfc5424logging/adapter.py
+++ b/rfc5424logging/adapter.py
@@ -18,8 +18,10 @@ class Rfc5424SysLogAdapter(logging.LoggerAdapter):
         adapter = Rfc5424SysLogAdapter(someLogger, dict(p1=v1, p2="v2"))
 
         Args:
-            logger:
+            logger (logging.Logger):
                 A Logger class instance
+            extra (dict):
+                A Dictionary with with extra contextual information
             enable_extra_levels (bool):
                 Add custom log levels to the logging framework.
                 Use with caution because it can conflict with other packages defining custom levels.
@@ -30,6 +32,9 @@ class Rfc5424SysLogAdapter(logging.LoggerAdapter):
             logging.addLevelName(ALERT, 'ALERT')
             logging.addLevelName(NOTICE, 'NOTICE')
             Rfc5424SysLogAdapter._extra_levels_enabled = True
+
+        if extra is not None and not isinstance(extra, dict):
+            raise TypeError("Parameter extra must be a dictionary")
 
         super(Rfc5424SysLogAdapter, self).__init__(logger, extra or {})
 
@@ -51,7 +56,7 @@ class Rfc5424SysLogAdapter(logging.LoggerAdapter):
             structured_data = kwargs.pop('structured_data', None)
 
         extra = self.extra.copy()
-        extra.update(kwargs['extra'] or {})
+        extra.update(kwargs.get('extra', {}))
         kwargs['extra'] = extra
 
         if hostname:

--- a/rfc5424logging/adapter.py
+++ b/rfc5424logging/adapter.py
@@ -50,10 +50,9 @@ class Rfc5424SysLogAdapter(logging.LoggerAdapter):
         if structured_data is None:
             structured_data = kwargs.pop('structured_data', None)
 
-        if 'extra' not in kwargs:
-            kwargs['extra'] = {}
-        if self.extra:
-            kwargs['extra'].update(self.extra)
+        extra = self.extra.copy()
+        extra.update(kwargs['extra'] or {})
+        kwargs['extra'] = extra
 
         if hostname:
             kwargs['extra']['hostname'] = hostname

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -204,8 +204,12 @@ def test_empty_msg(logger_with_udp_handler):
 
 def test_extras(logger_with_udp_handler):
     logger, syslog_socket = logger_with_udp_handler
-    adapter = Rfc5424SysLogAdapter(logger, enable_extra_levels=True, extra={"a": 1})
-    expected_return = ("aaaa", {'extra': dict(a=1, b=2)})
-    assert adapter.process("aaaa", kwargs={'extra': {"b": 2}}) == expected_return
-    expected_return = ("aaaa", {'extra': dict(a=11)})
-    assert adapter.process("aaaa", kwargs={'extra': {"a": 11}}) == expected_return
+    adapter = Rfc5424SysLogAdapter(logger, enable_extra_levels=True, extra={"a": 1, "c": 3})
+    expected_return = ("aaaa", {'extra': dict(a=1, b=2, c="c")})
+    # Make sure passed extra argument overrides that of the adapter instance
+    assert adapter.process("aaaa", kwargs={'extra': {"b": 2, "c": "c"}}) == expected_return
+    # Make sure adapter instance variables aren't overwritten
+    assert {"a": 1, "c": 3} == adapter.extra
+    # Test invalid extra argument
+    with pytest.raises(TypeError):
+        adapter = Rfc5424SysLogAdapter(logger, enable_extra_levels=True, extra="i_am_not_a_dict")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -207,3 +207,5 @@ def test_extras(logger_with_udp_handler):
     adapter = Rfc5424SysLogAdapter(logger, enable_extra_levels=True, extra={"a": 1})
     expected_return = ("aaaa", {'extra': dict(a=1, b=2)})
     assert adapter.process("aaaa", kwargs={'extra': {"b": 2}}) == expected_return
+    expected_return = ("aaaa", {'extra': dict(a=11)})
+    assert adapter.process("aaaa", kwargs={'extra': {"a": 11}}) == expected_return


### PR DESCRIPTION
This PR is related to commit dcd32d1.
When an extra is given twice: in __init__ and in a local call to logger, I think the local value should override the first one. My opinion.
Note: I really dislike my loop too :-). So you can discard my PR if you find a more elegant way to implement this override.

Signed-off-by: Cyril Martin <c.martin@criteo.com>