### PR TITLE
Disable checking hostname when tls verify is false

### DIFF
--- a/rfc5424logging/transport.py
+++ b/rfc5424logging/transport.py
@@ -90,6 +90,7 @@ class TLSSocketTransport(TCPSocketTransport):
         context = ssl.create_default_context(
             purpose=ssl.Purpose.SERVER_AUTH, cafile=self.tls_ca_bundle
         )
+        context.check_hostname = self.tls_verify
         context.verify_mode = ssl.CERT_REQUIRED if self.tls_verify else ssl.CERT_NONE
         server_hostname, _ = self.address
         if self.tls_client_cert:


### PR DESCRIPTION
Closes #40 

Not setting `check_hostname` to `False` when `tls_verify` is `False` triggers the following exception. The PR contains changes to disable hostname checking when tls verification is disabled.

```python
...
File ".../lib/python3.8/site-packages/rfc5424logging/handler.py", line 229, in __init__
    self._setup_transport()
  File ".../lib/python3.8/site-packages/rfc5424logging/handler.py", line 239, in _setup_transport
    self.transport = transport.TLSSocketTransport(
  File ".../lib/python3.8/site-packages/rfc5424logging/transport.py", line 86, in __init__
    super(TLSSocketTransport, self).__init__(address, timeout, framing=framing)
  File ".../lib/python3.8/site-packages/rfc5424logging/transport.py", line 26, in __init__
    self.open()
  File ".../lib/python3.8/site-packages/rfc5424logging/transport.py", line 94, in open
    context.verify_mode = ssl.CERT_REQUIRED if self.tls_verify else ssl.CERT_NONE
  File "/usr/lib/python3.8/ssl.py", line 720, in verify_mode
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```