### PR TITLE
Add support for specifying tls ciphers

### DIFF
--- a/rfc5424logging/handler.py
+++ b/rfc5424logging/handler.py
@@ -106,6 +106,7 @@ class Rfc5424SysLogHandler(Handler):
             tls_client_cert=None,
             tls_client_key=None,
             tls_key_password=None,
+            tls_ciphers=None,
             stream=None,
     ):
         """
@@ -189,6 +190,8 @@ class Rfc5424SysLogHandler(Handler):
                 Path to a file containing the client private key.
             tls_key_password (str):
                 Optionally the password for decrypting the specified private key.
+            tls_ciphers (str):
+                Optionally the ciphers to use in the TLS connection.
             stream (io.BufferedIOBase, file, io.TextIOBase):
                 Optionally a stream object to send the message to. See https://docs.python.org/3/library/io.html
                 for details.
@@ -215,6 +218,7 @@ class Rfc5424SysLogHandler(Handler):
         self.tls_client_cert = tls_client_cert
         self.tls_client_key = tls_client_key
         self.tls_key_password = tls_key_password
+        self.tls_ciphers = tls_ciphers
         self.stream = stream
         self.transport = None
 
@@ -237,9 +241,15 @@ class Rfc5424SysLogHandler(Handler):
             if self.socktype == socket.SOCK_STREAM:
                 if self.tls_enable:
                     self.transport = transport.TLSSocketTransport(
-                        self.address, self.timeout, self.framing,
-                        self.tls_ca_bundle, self.tls_verify,
-                        self.tls_client_cert, self.tls_client_key, self.tls_key_password
+                        self.address,
+                        self.timeout,
+                        self.framing,
+                        self.tls_ca_bundle,
+                        self.tls_verify,
+                        self.tls_client_cert,
+                        self.tls_client_key,
+                        self.tls_key_password,
+                        self.tls_ciphers,
                     )
                 else:
                     self.transport = transport.TCPSocketTransport(self.address, self.timeout, self.framing)

--- a/rfc5424logging/transport.py
+++ b/rfc5424logging/transport.py
@@ -77,12 +77,14 @@ class TLSSocketTransport(TCPSocketTransport):
         tls_client_cert,
         tls_client_key,
         tls_key_password,
+        tls_ciphers,
     ):
         self.tls_ca_bundle = tls_ca_bundle
         self.tls_verify = tls_verify
         self.tls_client_cert = tls_client_cert
         self.tls_client_key = tls_client_key
         self.tls_key_password = tls_key_password
+        self.tls_ciphers = tls_ciphers
         super(TLSSocketTransport, self).__init__(address, timeout, framing=framing)
 
     def open(self):
@@ -90,6 +92,8 @@ class TLSSocketTransport(TCPSocketTransport):
         context = ssl.create_default_context(
             purpose=ssl.Purpose.SERVER_AUTH, cafile=self.tls_ca_bundle
         )
+        if self.tls_ciphers:
+            context.set_ciphers(self.tls_ciphers)
         context.verify_mode = ssl.CERT_REQUIRED if self.tls_verify else ssl.CERT_NONE
         server_hostname, _ = self.address
         if self.tls_client_cert:


### PR DESCRIPTION
The chages allow TLS ciphers to be specified as parameter for `Rfc5424SysLogHandler` which will be passed to the TLS connection's context.