### PR TITLE
Don't import tzlocal at top level

### DIFF
--- a/rfc5424logging/handler.py
+++ b/rfc5424logging/handler.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from logging import Handler
 
 from pytz import utc
-from tzlocal import get_localzone
 
 from rfc5424logging import transport
 
@@ -218,6 +217,9 @@ class Rfc5424SysLogHandler(Handler):
         self.stream = stream
         self.transport = None
 
+        from tzlocal import get_localzone
+        self._local_zone = get_localzone()
+
         if not (isinstance(self.facility, int) and LOG_KERN <= self.facility <= LOG_LOCAL7):
             raise ValueError("Facility is not valid")
 
@@ -366,7 +368,7 @@ class Rfc5424SysLogHandler(Handler):
         # HEADER
         pri = '<%d>' % self.encode_priority(self.facility, record.levelname)
         version = SYSLOG_VERSION
-        timestamp = datetime.fromtimestamp(record.created, get_localzone())
+        timestamp = datetime.fromtimestamp(record.created, self._local_zone)
         if self.utc_timestamp:
             timestamp = timestamp.astimezone(utc)
         timestamp = timestamp.isoformat()


### PR DESCRIPTION
tzlocal 5 now uses logging, which means that rfc5424 gets a recursive import error with tzlocal 5.0.1 and later. This PR solves that, and also does not call tzlocal every time a message is formatted. tzlocals get_localzone() does cache the result, so it's not a big burden, but it's still not necessary.

An alternative solution is to store the get_localzone method on the logger, if you want to be able refreshing the local zone at runtime, but the feature was implemented to support testing, I really don't think anyone uses it.